### PR TITLE
remove unused PropTypes and ReactReduxContext

### DIFF
--- a/src/withFirebase.js
+++ b/src/withFirebase.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import PropTypes from 'prop-types'
 import { clearInitialization } from 'firekit'
 import { initConnection, unsubscribeConnection } from 'firekit'
 import { watchAuth, authStateChanged, authError } from 'firekit'
@@ -9,7 +8,6 @@ import { watchPath, unwatchPath, destroyPath, unwatchAllPaths } from 'firekit'
 import { watchDoc, unwatchDoc, destroyDoc, unwatchAllDocs } from 'firekit'
 import { initMessaging, clearMessage } from 'firekit'
 import { FirekitContext } from './components/Context'
-import { ReactReduxContext } from 'react-redux'
 
 const withFirebase = Component => {
   const ChildComponent = props => {


### PR DESCRIPTION
Hi, I'm trying to use this lib in one of my projects and I got some errors. I checked the source of this lib and made small changes. I found importing `ReactReduxContext` confusing, since it's also redeclared when destructuring context variable.

So I removed both unused imports. Should fix #3 